### PR TITLE
Allow user to see status of his instances

### DIFF
--- a/src/syme/db.clj
+++ b/src/syme/db.clj
@@ -51,6 +51,12 @@
           (assoc instance
             :invitees (mapv :invitee invitees)))))))
 
+(defn find-all [username]
+  (sql/with-connection db
+    (sql/with-query-results instances
+      ["SELECT * FROM instances WHERE owner = ? ORDER BY at DESC" username]
+      (doall instances))))
+
 (defn by-token [shutdown-token]
   (sql/with-connection db
     (sql/with-query-results [instance]

--- a/src/syme/html.clj
+++ b/src/syme/html.clj
@@ -30,7 +30,9 @@
        " | " [:a {:href "https://github.com/technomancy/syme"}
               "Source"]
        " | " (if username
-               [:a {:href "/logout"} "Log out"]
+               (list [:a {:href "/status"} "Status"]
+                     " | "
+                     [:a {:href "/logout"} "Log out"])
                [:a {:href login-url} "Log in"])]]]]))
 
 (defn splash [username]
@@ -77,12 +79,23 @@
 
 (defonce icon (memoize (comp :avatar_url users/user)))
 
-(defn instance [username {:keys [project status description ip invitees]}]
+(defn- link-syme-project [project]
+  (format "/project/%s" project))
+
+(defn- link-github-project [project]
+  (format "https://github.com/%s" project))
+
+(defn- render-instance-info [{status :status project :project description :description} link-project]
+  [:p
+   [:p {:id "status" :class status} status]
+   [:h3.project [:a {:href (link-project project)} project]]
+   [:p {:id "desc"} description]])
+
+(defn instance [username {:keys [project status description ip invitees]
+                          :as instance-info}]
   (layout
    [:div
-    [:p {:id "status" :class status} status]
-    [:h3.project [:a {:href (format "https://github.com/%s" project)} project]]
-    [:p {:id "desc"} description]
+    (render-instance-info instance-info link-github-project)
     [:hr]
     (if ip
       [:div
@@ -106,3 +119,20 @@
                         (format "watch_status('%s')" project)
                         (format "wait_for_boot('%s')" project))}]]
    username project))
+
+(defn status [username instances]
+  (layout
+   [:div
+    [:h3 "Instances"]
+    (if instances
+      (map #(render-instance-info % link-syme-project) instances)
+      [:p "You have no instances"])
+    [:p
+     "You may want to periodically check your "
+     [:a {:href "https://console.aws.amazon.com/ec2/home?region=us-west-2#s=Instances"}
+      "AWS EC2 console"]
+     " to ensure you aren't billed for instances you intended to stop that"
+     " stayed running due to problems with Syme. In particular this happens"
+     " due to timeout errors."
+     ]]
+   username "Status"))

--- a/src/syme/web.clj
+++ b/src/syme/web.clj
@@ -38,6 +38,8 @@
         {:headers {"Content-Type" "text/html"}
          :status 200
          :body (html/splash username)})
+   (GET "/status" {{:keys [username]} :session}
+        (html/status username (db/find-all username)))
    (GET "/launch" {{:keys [username] :as session} :session
                    {:keys [project]} :params}
         (if-let [instance (db/find username project)]


### PR DESCRIPTION
This commit doesn't follow issue #6 exactly as it simply lists all user's instances from DB.
