### PR TITLE
Use project name as EC2 instance name

### DIFF
--- a/src/syme/instance.clj
+++ b/src/syme/instance.clj
@@ -18,7 +18,9 @@
                                              ImportKeyPairRequest
                                              RunInstancesRequest
                                              DescribeInstancesRequest
-                                             TerminateInstancesRequest)
+                                             TerminateInstancesRequest
+                                             CreateTagsRequest
+                                             Tag)
            (org.apache.commons.codec.binary Base64)))
 
 (defn make-client [identity credential]
@@ -96,6 +98,12 @@
                                             (Base64/encodeBase64
                                              (.getBytes user-data-script)))))))
 
+(defn set-instance-name [client id name]
+  (let [tag-name-request (-> (CreateTagsRequest.)
+                         (.withResources [id])
+                         (.withTags [(Tag. "Name" name)]))]
+    (.createTags client tag-name-request)))
+
 (defn poll-for-ip [client id tries]
   (let [describe-request (-> (DescribeInstancesRequest.)
                              (.withInstanceIds [id]))]
@@ -144,6 +152,8 @@
         (let [result (run-instance client security-group-name
                                    (user-data username project invitees))
               id (-> result .getReservation .getInstances first .getInstanceId)]
+          (println "setting instance name to" project)
+          (set-instance-name client id project)
           (println "waiting for IP...")
           (let [ip (poll-for-ip client id 0)]
             (println "got IP:" ip)


### PR DESCRIPTION
so that it's easier for the user to find out which instance is being
used by given project.
