### PR TITLE
Language Detection Doesn't Seem to be Working

### DIFF
--- a/src/syme/instance.clj
+++ b/src/syme/instance.clj
@@ -75,8 +75,14 @@
                     (map :login (orgs/members (subs org 1))))]
     (apply concat users orgs-users)))
 
+(defn primary-language [project]
+  (->> (apply repos/languages (.split project "/"))
+       (apply max-key second)
+       first
+       name))
+
 (defn user-data [username project invitees]
-  (let [{:keys [language]} (apply repos/specific-repo (.split project "/"))
+  (let [language (primary-language project)
         {:keys [name email]} (users/user username)
         {:keys [shutdown_token]} (db/find username project)
         language-script (io/resource (str "languages/" language ".sh"))]


### PR DESCRIPTION
When we started an instance at seajure on the nrepl-discover project, it didn't have the JDK installed, so you mentioned that the language detection wasn't working.
